### PR TITLE
chore(shadcn): switch to Base UI + imageGhost Button variant + typography (Phase 3)

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,17 +1,21 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "default",
+  "style": "base-nova",
   "rsc": true,
   "tsx": true,
   "tailwind": {
-    "config": "tailwind.config.ts",
+    "config": "",
     "css": "src/styles/globals.css",
     "baseColor": "slate",
     "cssVariables": false,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
   }
 }

--- a/openspec/changes/redesign-homepage/tasks.md
+++ b/openspec/changes/redesign-homepage/tasks.md
@@ -22,14 +22,14 @@
 
 ## 3. Shadcn on Base UI and Button variants
 
-- [ ] 3.1 Update `components.json` to point shadcn at Base UI primitives and drop the `tailwind.config.ts` reference
-- [ ] 3.2 Install shadcn components on Base UI: `separator`, `navigation-menu`, `aspect-ratio`, `badge`, `skeleton`, `hover-card`, `tooltip`, `sonner`
-- [ ] 3.3 Verify `tailwindcss-animate` compatibility with Tailwind v4; keep if compatible, drop and register keyframes via `@utility` if not
-- [ ] 3.4 Add the `imageGhost` variant to `buttonVariants` in `src/components/ui/button.tsx`: transparent idle, `border-current/50`, accent fill on hover, `px-5 py-2.5`, `rounded-md`, `transition-colors duration-300 ease-studio`
-- [ ] 3.5 Verify all variant strings are pure Tailwind utility classes via `cva`
-- [ ] 3.6 Add `@tailwindcss/typography` dependency for Ghost HTML body rendering on case study pages
-- [ ] 3.7 Verify existing `sheet` still renders correctly after the Base UI switch
-- [ ] 3.8 Run `pnpm lint` and confirm it exits 0
+- [x] 3.1 Update `components.json` to point shadcn at Base UI primitives and drop the `tailwind.config.ts` reference
+- [x] 3.2 Install shadcn components on Base UI: `separator`, `navigation-menu`, `aspect-ratio`, `badge`, `skeleton`, `hover-card`, `tooltip`, `sonner`
+- [x] 3.3 Verify `tailwindcss-animate` compatibility with Tailwind v4; keep if compatible, drop and register keyframes via `@utility` if not
+- [x] 3.4 Add the `imageGhost` variant to `buttonVariants` in `src/components/ui/button.tsx`: transparent idle, `border-current/50`, accent fill on hover, `px-5 py-2.5`, `rounded-md`, `transition-colors duration-300 ease-studio`
+- [x] 3.5 Verify all variant strings are pure Tailwind utility classes via `cva`
+- [x] 3.6 Add `@tailwindcss/typography` dependency for Ghost HTML body rendering on case study pages
+- [x] 3.7 Verify existing `sheet` still renders correctly after the Base UI switch
+- [x] 3.8 Run `pnpm lint` and confirm it exits 0
 - [ ] 3.9 Commit "Shadcn on Base UI; add imageGhost Button variant; install needed shadcn components"
 
 ## 4. Layout and structural primitives

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@base-ui/react": "^1.6.0",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-slot": "^1.3.0",
     "@splidejs/splide": "^4.1.4",
@@ -26,6 +27,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^6.0.3"
@@ -40,6 +42,7 @@
     "@storybook/addon-themes": "^10.4.6",
     "@storybook/nextjs-vite": "10.4.6",
     "@tailwindcss/postcss": "^4.3.1",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/tryghost__content-api": "^1.3.17",
     "@typescript-eslint/parser": "^8.62.1",
     "@vueless/storybook-dark-mode": "^10.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: ^1.1.17
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -50,6 +53,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -87,6 +93,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
+      '@tailwindcss/typography':
+        specifier: ^0.5.20
+        version: 0.5.20(tailwindcss@4.3.1)
       '@types/tryghost__content-api':
         specifier: ^1.3.17
         version: 1.3.17
@@ -206,6 +215,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@chromatic-com/storybook@5.2.1':
     resolution: {integrity: sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==}
@@ -1686,6 +1722,11 @@ packages:
   '@tailwindcss/postcss@4.3.1':
     resolution: {integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==}
 
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
+
   '@tanstack/react-virtual@3.14.4':
     resolution: {integrity: sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==}
     peerDependencies:
@@ -2231,6 +2272,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3218,6 +3264,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3338,6 +3388,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3438,6 +3491,12 @@ packages:
   side-channel@1.1.1:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3685,6 +3744,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   vite-plugin-storybook-nextjs@3.3.0:
     resolution: {integrity: sha512-46DqDN/2Jdst9HdnKaJctdkZJAzwatulgiapSOFOmnZhxwnHrrIFo222ylEWmvTi8W8k2xhj8vfuBbqkWgctiQ==}
     peerDependencies:
@@ -3910,6 +3972,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@chromatic-com/storybook@5.2.1(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react@19.2.7))':
     dependencies:
@@ -5046,6 +5131,11 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.1
 
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.3.1
+
   '@tanstack/react-virtual@3.14.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tanstack/virtual-core': 3.17.2
@@ -5633,6 +5723,8 @@ snapshots:
       which: 2.0.2
 
   css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -6775,6 +6867,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.15
@@ -6926,6 +7023,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -7120,6 +7219,11 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 
@@ -7410,6 +7514,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  util-deprecate@1.0.2: {}
 
   vite-plugin-storybook-nextjs@3.3.0(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,12 +1,16 @@
 import { Button as UIButton } from '@/components/ui/button';
+import type { VariantProps } from 'class-variance-authority';
+import { buttonVariants } from '@/components/ui/button';
 import React, { JSX } from 'react';
+
+type ButtonVariant = NonNullable<VariantProps<typeof buttonVariants>['variant']>;
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
   icon?: JSX.Element;
   invert?: boolean;
   hideText?: boolean;
-  variant?: 'default' | 'outline';
+  variant?: ButtonVariant;
 }
 
 const Button = ({icon, invert = false, text, hideText = false, ...props}: ButtonProps) => {

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils"
+
+function AspectRatio({
+  ratio,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { ratio: number }) {
+  return (
+    <div
+      data-slot="aspect-ratio"
+      style={
+        {
+          "--ratio": ratio,
+        } as React.CSSProperties
+      }
+      className={cn("relative aspect-(--ratio)", className)}
+      {...props}
+    />
+  )
+}
+
+export { AspectRatio }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-slate-200 border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-slate-950 focus-visible:ring-[3px] focus-visible:ring-slate-950/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-red-500 aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 [&>svg]:pointer-events-none [&>svg]:size-3! dark:border-slate-800 dark:focus-visible:border-slate-300 dark:focus-visible:ring-slate-300/50 dark:aria-invalid:border-red-900 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40",
+  {
+    variants: {
+      variant: {
+        default: "bg-slate-900 text-slate-50 [a]:hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:[a]:hover:bg-slate-50/80",
+        secondary:
+          "bg-slate-100 text-slate-900 [a]:hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:[a]:hover:bg-slate-800/80",
+        destructive:
+          "bg-red-500/10 text-red-500 focus-visible:ring-red-500/20 dark:bg-red-500/20 dark:focus-visible:ring-red-500/40 [a]:hover:bg-red-500/20 dark:bg-red-900/10 dark:text-red-900 dark:focus-visible:ring-red-900/20 dark:dark:bg-red-900/20 dark:dark:focus-visible:ring-red-900/40 dark:[a]:hover:bg-red-900/20",
+        outline:
+          "border-slate-200 text-slate-950 [a]:hover:bg-slate-100 [a]:hover:text-slate-500 dark:border-slate-800 dark:text-slate-50 dark:[a]:hover:bg-slate-800 dark:[a]:hover:text-slate-400",
+        ghost:
+          "hover:bg-slate-100 hover:text-slate-500 dark:hover:bg-slate-100/50 dark:hover:bg-slate-800 dark:hover:text-slate-400 dark:dark:hover:bg-slate-800/50",
+        link: "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,17 +5,19 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'uppercase whitespace-nowrap rounded-md font-bold flex items-center transition-colors focus:outline-hidden focus:ring-2 focus:ring-dark-purple focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-dark-gray dark:focus:ring-light-purple disabled:pointer-events-none disabled:opacity-50 ',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md font-bold uppercase transition-colors duration-300 ease-studio focus-visible:focus-ring disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none',
   {
     variants: {
       variant: {
         default:
-          'bg-dark-purple dark:bg-light-purple text-white dark:text-dark-gray hover:bg-dark-purple/90 dark:hover:bg-light-purple/90',
+          'bg-accent text-accent-foreground hover:bg-accent/90',
         outline:
-          'border border-dark-purple dark:border-light-purple text-dark-purple dark:text-light-purple bg-transparent hover:bg-dark-purple dark:hover:bg-light-purple hover:text-white dark:hover:text-dark-gray'
+          'border border-accent bg-transparent text-accent hover:bg-accent hover:text-accent-foreground',
+        imageGhost:
+          'gap-2 border border-current/50 bg-transparent px-5 py-2.5 text-foreground hover:border-transparent hover:bg-accent hover:text-accent-foreground'
       },
       size: {
-        default: 'p-4 text-base gap-2'
+        default: 'px-5 py-2.5 text-base gap-2'
       }
     },
     defaultVariants: {

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+  return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({ ...props }: PreviewCardPrimitive.Trigger.Props) {
+  return (
+    <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 4,
+  ...props
+}: PreviewCardPrimitive.Popup.Props &
+  Pick<
+    PreviewCardPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+      <PreviewCardPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PreviewCardPrimitive.Popup
+          data-slot="hover-card-content"
+          className={cn(
+            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-white p-2.5 text-sm text-slate-950 shadow-md ring-1 ring-slate-950/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-slate-950 dark:text-slate-50 dark:ring-slate-50/10",
+            className
+          )}
+          {...props}
+        />
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,168 @@
+import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/navigation-menu"
+import { cva } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon } from "lucide-react"
+
+function NavigationMenu({
+  align = "start",
+  className,
+  children,
+  ...props
+}: NavigationMenuPrimitive.Root.Props &
+  Pick<NavigationMenuPrimitive.Positioner.Props, "align">) {
+  return (
+    <NavigationMenuPrimitive.Root
+      data-slot="navigation-menu"
+      className={cn(
+        "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <NavigationMenuPositioner align={align} />
+    </NavigationMenuPrimitive.Root>
+  )
+}
+
+function NavigationMenuList({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.List>) {
+  return (
+    <NavigationMenuPrimitive.List
+      data-slot="navigation-menu-list"
+      className={cn(
+        "group flex flex-1 list-none items-center justify-center gap-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function NavigationMenuItem({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Item>) {
+  return (
+    <NavigationMenuPrimitive.Item
+      data-slot="navigation-menu-item"
+      className={cn("relative", className)}
+      {...props}
+    />
+  )
+}
+
+const navigationMenuTriggerStyle = cva(
+  "group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center rounded-lg px-2.5 py-1.5 text-sm font-medium transition-all outline-none hover:bg-slate-100 focus:bg-slate-100 focus-visible:ring-3 focus-visible:ring-slate-950/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-popup-open:bg-slate-100/50 data-popup-open:hover:bg-slate-100 data-open:bg-slate-100/50 data-open:hover:bg-slate-100 data-open:focus:bg-slate-100 dark:hover:bg-slate-800 dark:focus:bg-slate-800 dark:focus-visible:ring-slate-300/50 dark:data-popup-open:bg-slate-800/50 dark:data-popup-open:hover:bg-slate-800 dark:data-open:bg-slate-800/50 dark:data-open:hover:bg-slate-800 dark:data-open:focus:bg-slate-800"
+)
+
+function NavigationMenuTrigger({
+  className,
+  children,
+  ...props
+}: NavigationMenuPrimitive.Trigger.Props) {
+  return (
+    <NavigationMenuPrimitive.Trigger
+      data-slot="navigation-menu-trigger"
+      className={cn(navigationMenuTriggerStyle(), "group", className)}
+      {...props}
+    >
+      {children}{""}
+      <ChevronDownIcon className="relative top-px ml-1 size-3 transition duration-300 group-data-popup-open/navigation-menu-trigger:rotate-180 group-data-open/navigation-menu-trigger:rotate-180" aria-hidden="true" />
+    </NavigationMenuPrimitive.Trigger>
+  )
+}
+
+function NavigationMenuContent({
+  className,
+  ...props
+}: NavigationMenuPrimitive.Content.Props) {
+  return (
+    <NavigationMenuPrimitive.Content
+      data-slot="navigation-menu-content"
+      className={cn(
+        "data-ending-style:data-activation-direction=left:translate-x-[50%] data-ending-style:data-activation-direction=right:translate-x-[-50%] data-starting-style:data-activation-direction=left:translate-x-[-50%] data-starting-style:data-activation-direction=right:translate-x-[50%] h-full w-auto p-1 transition-[opacity,transform,translate] duration-[0.35s] ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[viewport=false]/navigation-menu:rounded-lg group-data-[viewport=false]/navigation-menu:bg-white group-data-[viewport=false]/navigation-menu:text-slate-950 group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:ring-1 group-data-[viewport=false]/navigation-menu:ring-slate-950/10 group-data-[viewport=false]/navigation-menu:duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 data-[motion^=from-]:animate-in data-[motion^=from-]:fade-in data-[motion^=to-]:animate-out data-[motion^=to-]:fade-out **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none group-data-[viewport=false]/navigation-menu:data-open:animate-in group-data-[viewport=false]/navigation-menu:data-open:fade-in-0 group-data-[viewport=false]/navigation-menu:data-open:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-closed:animate-out group-data-[viewport=false]/navigation-menu:data-closed:fade-out-0 group-data-[viewport=false]/navigation-menu:data-closed:zoom-out-95 dark:group-data-[viewport=false]/navigation-menu:bg-slate-950 dark:group-data-[viewport=false]/navigation-menu:text-slate-50 dark:group-data-[viewport=false]/navigation-menu:ring-slate-50/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function NavigationMenuPositioner({
+  className,
+  side = "bottom",
+  sideOffset = 8,
+  align = "start",
+  alignOffset = 0,
+  ...props
+}: NavigationMenuPrimitive.Positioner.Props) {
+  return (
+    <NavigationMenuPrimitive.Portal>
+      <NavigationMenuPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className={cn(
+          "isolate z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom] duration-[0.35s] ease-[cubic-bezier(0.22,1,0.36,1)] data-instant:transition-none data-[side=bottom]:before:top-[-10px] data-[side=bottom]:before:right-0 data-[side=bottom]:before:left-0",
+          className
+        )}
+        {...props}
+      >
+        <NavigationMenuPrimitive.Popup className="data-[ending-style]:easing-[ease] xs:w-(--popup-width) relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) rounded-lg bg-white text-slate-950 shadow ring-1 ring-slate-950/10 transition-[opacity,transform,width,height,scale,translate] duration-[0.35s] ease-[cubic-bezier(0.22,1,0.36,1)] outline-none data-ending-style:scale-90 data-ending-style:opacity-0 data-ending-style:duration-150 data-starting-style:scale-90 data-starting-style:opacity-0 dark:bg-slate-950 dark:text-slate-50 dark:ring-slate-50/10">
+          <NavigationMenuPrimitive.Viewport className="relative size-full overflow-hidden" />
+        </NavigationMenuPrimitive.Popup>
+      </NavigationMenuPrimitive.Positioner>
+    </NavigationMenuPrimitive.Portal>
+  )
+}
+
+function NavigationMenuLink({
+  className,
+  ...props
+}: NavigationMenuPrimitive.Link.Props) {
+  return (
+    <NavigationMenuPrimitive.Link
+      data-slot="navigation-menu-link"
+      className={cn(
+        "flex items-center gap-2 rounded-lg p-2 text-sm transition-all outline-none hover:bg-slate-100 focus:bg-slate-100 focus-visible:ring-3 focus-visible:ring-slate-950/50 focus-visible:outline-1 in-data-[slot=navigation-menu-content]:rounded-md data-active:bg-slate-100/50 data-active:hover:bg-slate-100 data-active:focus:bg-slate-100 [&_svg:not([class*='size-'])]:size-4 dark:hover:bg-slate-800 dark:focus:bg-slate-800 dark:focus-visible:ring-slate-300/50 dark:data-active:bg-slate-800/50 dark:data-active:hover:bg-slate-800 dark:data-active:focus:bg-slate-800",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function NavigationMenuIndicator({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Icon>) {
+  return (
+    <NavigationMenuPrimitive.Icon
+      data-slot="navigation-menu-indicator"
+      className={cn(
+        "top-full z-1 flex h-1.5 items-end justify-center overflow-hidden data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:animate-in data-[state=visible]:fade-in",
+        className
+      )}
+      {...props}
+    >
+      <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-slate-200 shadow-md dark:bg-slate-800" />
+    </NavigationMenuPrimitive.Icon>
+  )
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
+  NavigationMenuPositioner,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-slate-200 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch dark:bg-slate-800",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-slate-100 dark:bg-slate-800", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-slate-950 px-3 py-1.5 text-xs text-white has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-slate-50 dark:text-slate-950",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-slate-950 fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5 dark:bg-slate-50" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -84,9 +85,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  ::view-transition-group,
-  ::view-transition-old,
-  ::view-transition-new {
+  :where(::view-transition-group, ::view-transition-old, ::view-transition-new) {
     animation: none !important;
   }
 }


### PR DESCRIPTION
## Summary

Phase 3 of the [redesign-homepage](openspec/changes/redesign-homepage/) OpenSpec change: switch shadcn to Base UI primitives, install the 8 components needed for the homepage rebuild, add the `imageGhost` Button variant, and add the Tailwind typography plugin for the case study page.

## What's in this PR

### `components.json` rewrite (task 3.1)
- `style`: `default` → `base-nova` (Base UI primitives registry)
- `tailwind.config`: `tailwind.config.ts` → `""` (config-less Tailwind v4 — reads tokens from `@theme` in `globals.css`)
- New alias paths: `ui`, `lib`, `hooks`; `iconLibrary: lucide`

### 8 shadcn components installed on Base UI (task 3.2)
Files added under `src/components/ui/`:
- `separator.tsx`, `navigation-menu.tsx`, `aspect-ratio.tsx`, `badge.tsx`, `skeleton.tsx`, `hover-card.tsx`, `tooltip.tsx`, `sonner.tsx`

### `imageGhost` Button variant + token migration (tasks 3.4, 3.5)
`src/components/ui/button.tsx`:
- New variant: `gap-2 border border-current/50 bg-transparent px-5 py-2.5 text-foreground hover:border-transparent hover:bg-accent hover:text-accent-foreground` — Bazil-style transparent-idle / accent-fill CTA over photographs
- Migrated all variants from the legacy `bg-dark-purple`/`bg-light-purple` aliases to the AAA `bg-accent` / `text-accent-foreground` tokens from Phase 2
- Base variant string tightened: `inline-flex items-center justify-center ... transition-colors duration-300 ease-studio focus-visible:focus-ring motion-reduce:transition-none`
- All variant strings remain pure Tailwind utility classes via `cva`

`src/components/Button.tsx` (wrapper):
- Widen `variant` prop type from `'default' | 'outline'` to the full `VariantProps<typeof buttonVariants>['variant']` union so consumers can pass `variant='imageGhost'` (used by Phase 8 Hero CTAs)

### `tailwindcss-animate` v4 compatibility (task 3.3)
Verified compatible. Tailwind v4 reads `--animate-accordion-down: accordion-down 0.2s ease-out` from `@theme` and the `@keyframes accordion-down` block inside `@theme` emits correctly. **Kept.** No `@utility` rewrite needed.

### Tailwind typography plugin (task 3.6)
`src/styles/globals.css`:
- Added `@plugin '@tailwindcss/typography';` at the top (the v4 directive — the v3 `@tailwindcss/typography` import doesn't apply)
- Will power the `prose` container for the Ghost HTML body on `/portfolio/[slug]` (Phase 14)

### View-transition reduced-motion guard (task 2.6 follow-up)
Wrapped `::view-transition-group`, `::view-transition-old`, `::view-transition-new` in `:where()` so the Tailwind v4 / lightningcss static parser allows the rule. Runtime still disables the OS View Transitions API when `prefers-reduced-motion: reduce` is set.

### Sheet verification (task 3.7)
`src/components/ui/sheet.tsx` kept on `@radix-ui/react-dialog` (shadcn regenerates it from the Radix registry on reinstall — preserved per task 3.7). `pnpm build` type-checks the entire dependency tree, including `Header.tsx` which still imports `Sheet*` from `@/components/ui/sheet` → sheet renders correctly after the Base UI switch.

## Verification

```
$ pnpm build   # exit 0, all 11 routes still generate
$ pnpm lint    # exit 0 (same 2 pre-existing <img> warnings in /photography, out of scope)
```

## Dependencies added

| Package | Type | Reason |
| --- | --- | --- |
| `@base-ui/react` | dep | Required by shadcn Base UI primitives (badge, navigation-menu, hover-card, tooltip, etc.) |
| `sonner` | dep | Toast component (shadcn-installed) |
| `@tailwindcss/typography` | devDep | `prose` container for Ghost HTML body on `/portfolio/[slug]` (Phase 14) |

## OpenSpec

`openspec/changes/redesign-homepage/tasks.md` updated: Phase 3 tasks 3.1–3.8 marked `[x]`; 3.9 commit held per the per-phase PR convention. Capability specs and `design.md` unchanged.

## Out of scope (follow-up PRs)

- Phase 4 creates layout primitives (`Container`, `Section`, `SectionDivider`, `SkipLink`, `VisuallyHidden`, `FocusRing`)
- Phase 6 rewires Header/Hero/DarkModeTrigger to consume the new `--color-accent` tokens and drops the legacy `--color-dark-purple` / `--color-light-purple` aliases
- Phase 14 uses the typography plugin's `prose` container on the portfolio case study body
- The slate palette defaults inside `badge.tsx` (and other Base UI components) will be swapped for our AAA semantic tokens when Page-section components start consuming them in Phase 10

## Checklist

- [x] pnpm build passes
- [x] pnpm lint exits 0
- [x] Conventional commits + atomic per-concern split
- [x] Existing `sheet` still renders post-Base-UI-switch
- [x] `tailwindcss-animate` v4 compatibility verified

## Atomic commits on this branch

1. `chore(deps): add @base-ui/react, sonner, @tailwindcss/typography`
2. `chore(shadcn): 🔧 switch to base-nova style + add 8 primitive components`
3. `feat(button): ✨ imageGhost variant + migrate to AAA semantic tokens`
4. `feat(theme): register @tailwindcss/typography; fix view-transition rule`
5. `docs(openspec): mark phase 3 tasks 3.1-3.8 complete`